### PR TITLE
Fixing the linking of the tests on the Lugano cluster.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,8 +2,10 @@
 #
 # Change this number when adding tests to force a CMake run: 7
 
+# Avoid link errors with boost on windows
 add_definitions(-DBOOST_PROGRAM_OPTIONS_DYN_LINK)
-set(TEST_LIBRARIES Collage)
+
+set(TEST_LIBRARIES Collage ${Boost_PROGRAM_OPTIONS_LIBRARY})
 include(CommonCTest)
 
 install(FILES ${TEST_FILES} DESTINATION share/Collage/tests COMPONENT examples)


### PR DESCRIPTION
Missing boost::program_options symbols when linking the tests. I couldn't find what the -DBOOST_PROGRAM_OPTIONS_DYN_LINK was supposed to do, maybe we need to remove it as well. All the other boost libraries are linked explicitly in the Collage project except this one.
