### PR TITLE
Unregister requests when they timeout to adapt to Lunchbox/#233.

### DIFF
--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -1,3 +1,3 @@
 # -*- mode: cmake -*-
-git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git 01507da)
+git_subproject(Lunchbox https://github.com/Eyescale/Lunchbox.git f78040e)
 git_subproject(Pression https://github.com/Eyescale/Pression.git 93883cf)

--- a/co/localNode.cpp
+++ b/co/localNode.cpp
@@ -775,11 +775,11 @@ LocalNode::SendToken LocalNode::acquireSendToken( NodePtr node )
     {
         request.wait( Global::getTimeout( ));
     }
-    catch( lunchbox::FutureTimeout& )
+    catch( const lunchbox::FutureTimeout& )
     {
         LBERROR << "Timeout while acquiring send token " << request.getID()
                 << std::endl;
-        request.relinquish();
+        request.unregister();
         return 0;
     }
     return new co::SendToken( node );
@@ -1046,11 +1046,11 @@ uint32_t LocalNode::_connect( NodePtr node, ConnectionPtr connection )
     {
         connected = request.wait( 10000 /*ms*/ );
     }
-    catch( lunchbox::FutureTimeout& )
+    catch( const lunchbox::FutureTimeout& )
     {
         LBWARN << "Node connection handshake timeout - " << node
                << " not a Collage node?" << std::endl;
-        request.relinquish();
+        request.unregister();
         return CONNECT_TIMEOUT;
     }
 

--- a/co/zeroconf.h
+++ b/co/zeroconf.h
@@ -30,8 +30,8 @@ namespace detail { class Zeroconf; }
 /**
  * A zeroconf communicator.
  *
- * When Collage is compiled with Servus support (COLLAGE_USE_SERVUS), it uses the
- * ZeroConf service "_collage._tcp" to announce the presence of a listening
+ * When Collage is compiled with Servus support (COLLAGE_USE_SERVUS), it uses
+ * the ZeroConf service "_collage._tcp" to announce the presence of a listening
  * LocalNode using the zeroconf protocol, unless the LocalNode has no listening
  * connections. This class may be used to add additional key/value pairs to this
  * service to announce application-specific data, and to retrieve a snapshot of


### PR DESCRIPTION
I've grepped the source for "wait(" and "waitRequest(". I've fixed the code where wait appears with a timeout to unregister the request after the timeout and rethrow if needed; waitRequest never appears with a timeout.