### PR TITLE
Fixed two issues with RDMA connection establishment.

### DIFF
--- a/co/rdmaConnection.h
+++ b/co/rdmaConnection.h
@@ -280,7 +280,9 @@ private:
     std::string _device_name;
 
     /* RDMA/Verbs vars */
-    struct rdma_addrinfo *_rai;
+    struct rdma_addrinfo *_rai; // The addrinfo returned by rdma_getaddrinfo.
+    struct rdma_addrinfo *_addrinfo; // The addrinfo to be used. Points to
+                                     // one node in the list from _rai.
     struct rdma_event_channel *_cm;
     struct rdma_cm_id *_cm_id;
     struct rdma_cm_id *_new_cm_id;


### PR DESCRIPTION
In some systems rdma_getaddrinfo returns a list of addresses where
the first is from the AF_IB familiy. Apparently this only happens
in the client and the server, which binds using AF_INET[6] rejects
the connection.

In route resolution it is necessary to wait for the event
RDMA_CM_EVENT_ROUTE_RESOLVED fter using rdma_set_option when the
rdma_addrinfo struct contains routing information.