### PR TITLE
Fix compiler errors

### DIFF
--- a/CMake/Collage.spec
+++ b/CMake/Collage.spec
@@ -1,5 +1,5 @@
 Name:		Collage
-Version:	
+Version:	1.2.1
 Release:	1%{?dist}
 Summary:	Cross-platform C++ network library
 
@@ -7,7 +7,7 @@ Group:		Development/Libraries
 License:	LGPLv2
 URL:		http://www.libcollage.net/
 Source0:	http://www.equalizergraphics.com/downloads/%{name}-%{version}.tar.gz
-Patch0:		Collage--build-fix.patch
+Patch0:		Collage-1.2.1-build-fix.patch
 BuildRequires:	cmake
 BuildRequires:	boost-devel glew-devel lunchbox1
 

--- a/CMake/Collage.spec
+++ b/CMake/Collage.spec
@@ -1,5 +1,5 @@
 Name:		Collage
-Version:	1.2.1
+Version:	
 Release:	1%{?dist}
 Summary:	Cross-platform C++ network library
 
@@ -7,7 +7,7 @@ Group:		Development/Libraries
 License:	LGPLv2
 URL:		http://www.libcollage.net/
 Source0:	http://www.equalizergraphics.com/downloads/%{name}-%{version}.tar.gz
-Patch0:		Collage-1.2.1-build-fix.patch
+Patch0:		Collage--build-fix.patch
 BuildRequires:	cmake
 BuildRequires:	boost-devel glew-devel lunchbox1
 

--- a/co/dataIStream.h
+++ b/co/dataIStream.h
@@ -217,12 +217,17 @@ private:
     template <class T>
     void _read(T& value, const boost::false_type&)
     {
-        _readSerializable(value, boost::is_base_of<servus::Serializable, T>());
+        boost::is_base_of<servus::Serializable, T> base_of = boost::is_base_of<servus::Serializable, T>();
+        _readSerializable(value, &base_of);
     }
 
     /** Read a serializable object. */
     template <class T>
-    void _readSerializable(T& value, const boost::true_type&);
+    void _readSerializable(T& value, const boost::true_type*);
+
+    /** Catch for non-serializable object. */
+    template <class T>
+    void _readSerializable(T&, const boost::false_type*);
 
     /** Read an Array of POD data */
     template <class T>

--- a/co/dataIStream.ipp
+++ b/co/dataIStream.ipp
@@ -57,10 +57,15 @@ inline DataIStream& DataIStream::operator>>(Object*& object)
 
 /** Deserialize an inline serializable object. */
 template <class T>
-void DataIStream::_readSerializable(T& object, const boost::true_type&)
+void DataIStream::_readSerializable(T& object, const boost::true_type*)
 {
     const size_t size = read<size_t>();
     object.fromBinary(getRemainingBuffer(size), size);
+}
+
+template <class T>
+void DataIStream::_readSerializable(T&, const boost::false_type*)
+{
 }
 
 /** @cond IGNORE */

--- a/co/dataOStream.h
+++ b/co/dataOStream.h
@@ -238,12 +238,17 @@ private:
     template <class T>
     void _write(const T& value, const boost::false_type&)
     {
-        _writeSerializable(value, boost::is_base_of<servus::Serializable, T>());
+        boost::is_base_of<servus::Serializable, T> base_of = boost::is_base_of<servus::Serializable, T>();
+        _writeSerializable(value, &base_of);
     }
 
     /** Write a serializable object. */
     template <class T>
-    void _writeSerializable(const T& value, const boost::true_type&);
+    void _writeSerializable(const T& value, const boost::true_type*);
+
+    /** Catch for non-serializable object. */
+    template <class T>
+    void _writeSerializable(const T&, const boost::false_type*);
 
     /** Write an Array of POD data */
     template <class T>

--- a/co/dataOStream.ipp
+++ b/co/dataOStream.ipp
@@ -47,10 +47,15 @@ inline DataOStream& DataOStream::operator<<(const Object* const& object)
 
 /** Serialize an inline serializable object. */
 template <class T>
-void DataOStream::_writeSerializable(const T& object, const boost::true_type&)
+void DataOStream::_writeSerializable(const T& object, const boost::true_type*)
 {
     const auto& data = object.toBinary();
     (*this) << data.size << Array<const void>(data.ptr.get(), data.size);
+}
+
+template <class T>
+void DataOStream::_writeSerializable(const T&, const boost::false_type*)
+{
 }
 
 template <>


### PR DESCRIPTION
Added catch for is_base_of being false. Also needed to change data type to a pointer rather than struct itself.
Please double check that the false case should do nothing - I just created a dummy method that does nothing so that it could compile.